### PR TITLE
fix(tasks): Improve handling of units w. targets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: required
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible "ansible-lint>=3.4.15"
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Lint the role, but we don't want this to fail the build.
+  - ansible-lint tests/test.yml || echo -n ""
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  # No test written yet.
+  # - ansible-playbook tests/test.yml -i tests/inventory --connection=local
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Role Variables
 - `systemd_unit_install_state`: the default state to set units in (default: 'enabled')
 - `systemd_unit_install_remote`: whether unit file are to be taken from the local or the remote host (default: False).
 - `systemd_unit_install_user`: whether units are to be installed system-wide (False) or as per-user services (True) by default (default: False).
-- `systemd_unit_install_become`: whether to use privilege escalation is needed to install the unit (default: false).
-- `systemd_unit_install_become_user`: which priviledged identity is to be assumed to get enough privileges to install the unit (default: "root")
+
 
 Dependencies
 ------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,6 @@
     # Ensures we have a `tasks' attribute on all
     - "{{ (systemd_unit_install_units|rejectattr('tasks', 'undefined')|list) + (systemd_unit_install_units|selectattr('tasks', 'undefined')|map('combine', private['ansible_facts']['_systemd_unit_install_unit_descriptor_defaults'])|list) }}"
     - "tasks"
-  become: "{{systemd_unit_install_become}}"
-  become_user: "{{systemd_unit_install_become_user}}"
 
 - name: Enable/Start Systemd Unit
   systemd:
@@ -42,8 +40,6 @@
     # Ensures we have a `tasks' attribute on all
     - "{{ systemd_unit_install_units|rejectattr('tasks', 'undefined')|list + systemd_unit_install_units|selectattr('tasks', 'undefined')|map('combine', private['ansible_facts']['_systemd_unit_install_unit_descriptor_defaults'])|list }}"
     - "tasks"
-  become: "{{systemd_unit_install_become}}"
-  become_user: "{{systemd_unit_install_become_user}}"
 
 
 # vim: et:syntax=yaml:sw=2:ts=2:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
   template:
     src: "{{item.0.unit|default(omit)}}"
     content: "{{item.0.template|default(omit)}}"
-    dest: "{{item.0.directory|default(systemd_unit_install_dir) + '/' + item.0.unit|basename|splitext|first}}{% if item.1 %}@{{item.1}}{% endif %}.service"
+    dest: "{{item.0.directory|default(systemd_unit_install_dir) + '/' + item.0.unit|basename|splitext|first}}{% if item.1 %}@{{item.1}}{% endif %}{{item.0.unit|basename|splitext|last}}"
     remote_src: "{{item.0.remote|default(false)}}"
   with_subelements:
     # Ensures we have a `tasks' attribute on all
@@ -33,7 +33,7 @@
 
 - name: Enable/Start Systemd Unit
   systemd:
-    name: "{{item.0.unit|basename|splitext|first}}{% if item.1 %}@{{item.1}}.service{% else %}.service{% endif %}"
+    name: "{{item.0.unit|basename|splitext|first}}{% if item.1 %}@{{item.1}}{% endif %}{{item.0.unit|basename|splitext|last}}"
     enabled: "{{private['ansible_facts']['_systemd_unit_install_state_map'][item.0.state|default(systemd_unit_install_state)]._enabled}}"
     state: "{{private['ansible_facts']['_systemd_unit_install_state_map'][item.0.state|default(systemd_unit_install_state)]._state}}"
     user: "{{item.0.user|default(systemd_unit_install_user)}}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - systemd-install-unit
+    - role: systemd-unit-install


### PR DESCRIPTION
When installing non-service units (_e.g._ timer or sockets), the unit extension would be overridden by `.service` anyway. This fixes the issue. 